### PR TITLE
fix: Resume scheduled CI and use the correct branch name.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # schedule:
-  #   - cron: "31 1,12 * * *"
+  schedule:
+    - cron: "31 1,12 * * *"
 
   push:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration file `.github/workflows/main.yml`. The changes primarily focus on re-enabling the scheduled workflow and updating the branch name for push events.

Changes to GitHub Actions workflow configuration:

* Re-enabled the scheduled workflow by uncommenting and modifying the `schedule` section.
* Updated the branch name for push events from `main` to `master`.